### PR TITLE
Simple script to copy files from darwin folder to macos/ios folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pubspec.lock
 
 # VS Code
 .vscode
+
+.DS_Store

--- a/tools/cli/.gitignore
+++ b/tools/cli/.gitignore
@@ -1,0 +1,6 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build output.
+build/

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,0 +1,24 @@
+# Development tools
+
+### Swift development
+
+**Problem**
+
+Native `macos` and `ios` projects share most of the code. Sadly, CocoaPods does not allow to
+reference files outside of the root project directory, or to symlink `.swift` files.
+
+This would force us to duplicate the code between `macos` and `ios` implementations with cut &
+paste.
+
+**Solution**
+
+A simple script that watches a source folder (say `darwin`) and copies the files to the correct
+folder. Of course this means that most of future ios/macos developments will need to happen inside
+the source folder.
+
+**How to**
+Launch the script inside `tools/cli/lib`. Say you are in the root of the repository it would be
+
+```bash
+dart run ./tools/cli/lib/sync_darwin_folder.dart
+```

--- a/tools/cli/analysis_options.yaml
+++ b/tools/cli/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    prefer_single_quotes: false
+    unawaited_futures: false

--- a/tools/cli/lib/sync_darwin_folder.dart
+++ b/tools/cli/lib/sync_darwin_folder.dart
@@ -1,0 +1,64 @@
+import 'dart:core';
+import 'dart:io';
+
+import "package:path/path.dart" show dirname;
+import 'package:watcher/watcher.dart';
+
+void main(List<String> arguments) {
+  watch(
+    sourceFolder: "just_audio/darwin",
+    destinationFolders: [
+      "just_audio/macos",
+      "just_audio/ios",
+    ],
+  );
+}
+
+/// Watches files changes (add, modify and remove) inside the [sourceFolder], and aligns accordingly
+/// the [destinationFolders] files. Both [sourceFolder] and [destinationFolders] are supposed to be relative paths to the directory you want to operate with.
+///
+/// Throws a [FileSystemException] if [sourceFolder] does not exist.
+void watch({
+  required String sourceFolder,
+  required List<String> destinationFolders,
+}) {
+  final currentDir = dirname(Platform.script.path).dropLastSlash();
+  final baseDir = "$currentDir/../../..";
+  final destinationDirs = destinationFolders.map((it) {
+    return "$baseDir/${it.dropLastSlash()}";
+  });
+  final watcher = DirectoryWatcher("$baseDir/$sourceFolder");
+
+  watcher.events.listen((event) {
+    final partialPath = event.path.replaceAll("$baseDir/$sourceFolder", "");
+
+    print("Updating $partialPath");
+
+    switch (event.type) {
+      case ChangeType.ADD:
+      case ChangeType.MODIFY:
+        final file = File(event.path);
+        for (final destination in destinationDirs) {
+          file.copySync("$destination$partialPath");
+        }
+        break;
+      case ChangeType.REMOVE:
+        for (var element in destinationDirs) {
+          final file = File("$element$partialPath");
+          file.deleteSync(recursive: file is Directory);
+        }
+    }
+  });
+
+  print("🫣 Watching files 🫣");
+}
+
+extension StringPathClean on String {
+  String dropLastSlash() {
+    if (endsWith("/")) {
+      return substring(0, length - 1);
+    }
+
+    return this;
+  }
+}

--- a/tools/cli/pubspec.yaml
+++ b/tools/cli/pubspec.yaml
@@ -1,0 +1,13 @@
+name: cli
+description: Just Audio development utilities
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  path: ^1.8.2
+  watcher: ^1.0.1
+
+dev_dependencies:
+  lints: ^2.0.0


### PR DESCRIPTION
**Problem**

Native `macos` and `ios` projects share most of the code. Sadly, CocoaPods does not allow to reference files outside of the root project directory, or to symlink `.swift` files.

This would force us to duplicate the code between `macos` and `ios` implementations with cut & paste.

**Solution**

A simple script that watches a source folder (say `darwin`) and copies the files to the correct folder.
Of course this means that most of future ios/macos developments will need to happen inside the source folder.

**How to**
Launch the script inside `tools/cli/lib`. Say you are in the root of the repository it would be
```bash
dart run ./tools/cli/lib/cli.dart
```